### PR TITLE
do not allocate the option_endpoint_urls list

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+argus-pep-api-c 2.3.1
+---------------------
+* bug fix: do not allocate the option_endpoint_urls list
+
 argus-pep-api-c 2.3.0
 ---------------------
 * xacml_result_removeobligation(...) function added.

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 
 ##
 # VERSION number
-AC_INIT([argus-pep-api-c], [2.3.0], [argus-support@googlegroups.com])
+AC_INIT([argus-pep-api-c], [2.3.1], [argus-support@googlegroups.com])
 ##
 
 AC_CONFIG_AUX_DIR([project])

--- a/src/argus/pep.c
+++ b/src/argus/pep.c
@@ -163,15 +163,7 @@ PEP * pep_initialize(void) {
         return NULL;
     }
     
-    pep->option_endpoint_urls= pep_llist_create();
-    if (pep->option_endpoint_urls == NULL) {
-        pep_log_error("pep_initialize: endpoint URLs list allocation failed.");
-        curl_easy_cleanup(pep->curl);
-        pep_llist_delete(pep->pips);
-        pep_llist_delete(pep->ohs);
-        free(pep);
-        return NULL;
-    }
+    pep->option_endpoint_urls= NULL; // not used
     
     return pep;
 }


### PR DESCRIPTION
Since the list is not currently used, it's better to
not allocate it rather than properly destroy it in
pep_destroy(). The field could even be removed, but
it's kept there to avoid ABI-incompatibility risks.

fix issue #1